### PR TITLE
Fix Pwd on fast-merge

### DIFF
--- a/github/fast-merge/src/main.go
+++ b/github/fast-merge/src/main.go
@@ -13,6 +13,12 @@ import (
 func main() {
 	destinationBranch := os.Getenv("BRANCH")
 	push := os.Getenv("PUSH")
+	pwdEnv := os.Getenv("PWD")
+	err := os.Chdir(pwdEnv)
+	if err != nil {
+		log.Fatalf("Failed to chdir %s \n err: %v", pwdEnv, err)
+	}
+
 	currentBranch := execCommand("git rev-parse --abbrev-ref HEAD")
 
 	execCommand("git pull origin " + currentBranch)
@@ -35,7 +41,10 @@ func execCommand(value string) string {
 	stdout, _ := cmd.StdoutPipe()
 	var outError bytes.Buffer
 	cmd.Stderr = &outError
-	cmd.Start()
+	err := cmd.Start()
+	if err != nil {
+		log.Fatalf("Fail to start command %v\nParams: %v\nError: %v", command, params, err)
+	}
 	scanner := bufio.NewScanner(stdout)
 	scanner.Split(bufio.ScanLines)
 	commandResultMessage := ""
@@ -44,7 +53,7 @@ func execCommand(value string) string {
 		fmt.Println(m)
 		commandResultMessage += m
 	}
-	err := cmd.Wait()
+	err = cmd.Wait()
 	if err != nil {
 		log.Fatalf("Failed to execute command %v\nParams: %v\nError: %v", command, params, outError.String())
 	}


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/ritchie-formulas/blob/master/CONTRIBUTING.md

For additional information on our contributing process, read our contributing
guide https://docs.ritchiecli.io/community

Please provide the following information:
-->

**- What I did**
use the pwd env 
**- How I did it**
```go
       pwdEnv := os.Getenv("PWD")
	err := os.Chdir(pwdEnv)
	if err != nil {
		log.Fatalf("Failed to chdir %s \n err: %v", pwdEnv, err)
	}
```
**- How to verify it**
the github fast-merge is now working
**- Description for the changelog**
fix fast-merge to use pwd env
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
