### PR TITLE
Fix: Update README.md -> Page not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Execute one of the following commands through the `ritchie-formulas/Makefile` fi
 
 1. Fork the repository
 2. Create a branch: `git checkout -b <branch_name>`
-3. Check the step by step of [how to create formulas on Ritchie](https://docs.ritchiecli.io/developer/formulas/first-formula)
+3. Check the step by step of [how to create formulas on Ritchie](https://docs.ritchiecli.io/getting-started/creating-formulas)
 4. Add your formulas to the repository and commit your implementation: `git commit -m '<commit_message>'`
 5. Push your branch: `git push origin <project_name>/<location>`
 6. Open a pull request on the repository for analysis.


### PR DESCRIPTION
**- What I did**
Link "how to create formulas on Ritchie" ---> Page not found

**- How I did it**
Redirect link to "https://docs.ritchiecli.io/getting-started/creating-formulas" instead "https://docs.ritchiecli.io/developer/formulas/first-formula" because page not found

**- How to verify it**
Open page README.md and click at "How to create formulas on Ritchie" and page not found appears

**- Description for the changelog**
Link fix "How to create formulas on Ritchie"