### PR TITLE
Feature clean bucket

### DIFF
--- a/aws/bucket/clean-config.json
+++ b/aws/bucket/clean-config.json
@@ -1,0 +1,24 @@
+{
+  "command": "clean",
+  "description": "Clean bucket aws",
+  "inputs": [
+    {
+      "name" : "access_key",
+      "type" : "CREDENTIAL_AWS_ACCESSKEYID"
+    },
+    {
+      "name" : "secret_access_key",
+      "type" : "CREDENTIAL_AWS_SECRETACCESSKEY"
+    },
+    {
+      "name": "region",
+      "type": "text",
+      "label": "Type your region [ e.g us-east-1 ]: ",
+      "cache" : {
+        "active": true,
+        "qty" : 6,
+        "newLabel" : "Type new value. "
+      }
+    }
+  ]
+}

--- a/aws/bucket/src/pkg/bucket/bucket.go
+++ b/aws/bucket/src/pkg/bucket/bucket.go
@@ -93,6 +93,23 @@ func (in Inputs) runDelete(svc *s3.S3) {
 		return
 	}
 	bSelect, _ := prompt.List("Select bucket to delete: ", bItems)
+
+	listObjectsInput := &s3.ListObjectsInput{
+		Bucket: aws.String(bSelect),
+		MaxKeys: aws.Int64(1),
+	}
+
+	list, err := svc.ListObjects(listObjectsInput)
+	if err != nil {
+		fmt.Printf("Error on read bucket bucket %s, error: %v\n", bSelect, err)
+		return
+	}
+
+	if len(list.Contents) != 0 {
+		fmt.Printf("Bucket is not empty, please, execute the [rit aws clean bucket] command first.")
+		return
+	}
+
 	cItems := []string{"NO", "YES"}
 	c, _ := prompt.List(fmt.Sprintf("Confirm delete bucket name: %s", bSelect), cItems)
 	switch c {

--- a/aws/bucket/src/pkg/bucket/bucket.go
+++ b/aws/bucket/src/pkg/bucket/bucket.go
@@ -23,6 +23,7 @@ const (
 	list   = "list"
 	delete = "delete"
 	create = "create"
+	clean  = "clean"
 )
 
 func (in Inputs) Run() {
@@ -46,6 +47,8 @@ func (in Inputs) Run() {
 		in.runCreate(svc)
 	case delete:
 		in.runDelete(svc)
+	case clean:
+		in.runClean(svc)
 	default:
 		fmt.Printf("Command (%s) not found\n", in.Command)
 	}
@@ -105,6 +108,55 @@ func (in Inputs) runDelete(svc *s3.S3) {
 			return
 		}
 		fmt.Printf("Bucket %s deleted.\n", bSelect)
+	}
+}
+
+func (in Inputs) runClean(svc *s3.S3) {
+	res, err := in.list(svc)
+	if err != nil {
+		fmt.Printf("Error list bucket to clean, error: %v", err)
+	}
+	var bItems []string
+	for _, b := range res.Buckets {
+		bItems = append(bItems, aws.StringValue(b.Name))
+	}
+	if len(bItems) == 0 {
+		fmt.Printf("Not found bucket to clean")
+		return
+	}
+	bSelect, _ := prompt.List("Select bucket to clean: ", bItems)
+	confirm, _ := prompt.List(fmt.Sprintf("Confirm clean bucket name: %s", bSelect), []string{"NO", "YES"})
+	switch confirm {
+	case "NO":
+		fmt.Printf("Bucket %s not cleaned\n", bSelect)
+	case "YES":
+		fmt.Printf("Cleaning...")
+		listObjectsInput := &s3.ListObjectsInput{
+			Bucket: aws.String(bSelect),
+			MaxKeys: aws.Int64(20),
+		}
+
+		pageNum := 0
+		svc.ListObjectsPages(listObjectsInput, func(page *s3.ListObjectsOutput, lastPage bool) bool {
+			pageNum++
+			for _, value := range page.Contents {
+				deleteObjectInput := &s3.DeleteObjectInput{
+					Bucket: aws.String(bSelect),
+					Key: value.Key,
+				}
+
+				_, err := svc.DeleteObject(deleteObjectInput)
+				if err != nil {
+					fmt.Printf("Error on delete object %s, error: %v\n", err)
+					return false
+				}
+
+				fmt.Println("Deleted object: ", *value.Key)
+			}
+			return true
+		})
+
+		fmt.Printf("Bucket %s cleaned.\n", bSelect)
 	}
 }
 

--- a/aws/bucket/src/pkg/bucket/bucket.go
+++ b/aws/bucket/src/pkg/bucket/bucket.go
@@ -153,9 +153,7 @@ func (in Inputs) runClean(svc *s3.S3) {
 			MaxKeys: aws.Int64(20),
 		}
 
-		pageNum := 0
 		svc.ListObjectsPages(listObjectsInput, func(page *s3.ListObjectsOutput, lastPage bool) bool {
-			pageNum++
 			for _, value := range page.Contents {
 				deleteObjectInput := &s3.DeleteObjectInput{
 					Bucket: aws.String(bSelect),

--- a/tree/tree.json
+++ b/tree/tree.json
@@ -60,6 +60,18 @@
       }
     },
     {
+      "parent": "root_aws_clean",
+      "usage": "bucket",
+      "help": "Clean bucket",
+      "formula": {
+        "path": "aws/bucket",
+        "bin": "aws-bucket-${so}",
+        "bundle": "${so}.zip",
+        "config": "clean-config.json",
+        "repoUrl": "https://commons-repo.ritchiecli.io/formulas"
+      }
+    },
+    {
       "parent": "root_aws_delete",
       "usage": "bucket",
       "help": "Delete bucket",

--- a/tree/tree.json
+++ b/tree/tree.json
@@ -36,6 +36,11 @@
       "help": "Delete aws objects"
     },
     {
+      "parent": "root_aws",
+      "usage": "clean",
+      "help": "Clean aws objects"
+    },
+    {
       "parent": "root_aws_create",
       "usage": "bucket",
       "help": "Create bucket",


### PR DESCRIPTION
**- What I did**

- Added `rit aws clean bucket` option

- Adapted the `delete bucket` method to not allow the deletion of a bucket that is not empty

**- How I did it**

Using Aws Sdk to retrieve a list of objects in the bucket to delete then.

**- How to verify it**

- Run `rit aws clean bucket` to clean all objects of the bucket

- Run `rit aws delete bucket` in a non empty bucket must return the message:

> `Bucket is not empty, please, execute the [rit aws clean bucket] command first.`

**- Description for the changelog**
Added `rit aws clean bucket` option
