### PR TITLE
Fixing running go formula on Docker

### DIFF
--- a/templates/create_formula/languages/go/Dockerfile
+++ b/templates/create_formula/languages/go/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM cimg/go:1.14
 
 USER root
 


### PR DESCRIPTION
<!-- markdownlint-disable MD018 -->

# Pull Request

## What I did
Changed the image on the template to run go formulas properly. `alpine` does not support `curl -fsSL`

## How I did it
Updated the docker image to `cimg/go:1.14`

## How to verify it
Run a go formula with `--docker`

## What kind of change does this PR make

- [ ] Major
- [ ] Minor
- [x] Patch

<!--
See: https://semver.org/
-->

## Description for the changelog

Fixed bug not letting go formulas run with Docker
