### PR TITLE
Reduce the image size of nodejs docker formula

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -208,3 +208,7 @@ dist
 # End of https://www.toptal.com/developers/gitignore/api/node
 
 package-lock.json
+
+# Csharp output directories
+**/csharp/obj/**
+**/csharp/bin/**

--- a/templates/create_formula/languages/node/Dockerfile
+++ b/templates/create_formula/languages/node/Dockerfile
@@ -1,14 +1,14 @@
-FROM cimg/node:14.0
+FROM alpine:3.12
 
-USER root
+RUN mkdir /rit && \
+    apk add --no-cache sudo curl bash nodejs && \
+    curl -fsSL https://commons-repo.ritchiecli.io/install.sh | bash
 
-RUN curl -fsSL https://commons-repo.ritchiecli.io/install.sh | bash
-
-RUN mkdir /rit
 COPY . /rit
-RUN sed -i 's/\r//g' /rit/set_umask.sh
-RUN sed -i 's/\r//g' /rit/run.sh
-RUN chmod +x /rit/set_umask.sh
+
+RUN sed -i 's/\r//g' /rit/set_umask.sh && \
+    sed -i 's/\r//g' /rit/run.sh && \
+    chmod +x /rit/set_umask.sh
 
 WORKDIR /app
 ENTRYPOINT ["/rit/set_umask.sh"]

--- a/templates/create_formula/languages/node/Dockerfile
+++ b/templates/create_formula/languages/node/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM kobuti/make-runner:1.1.0
 
 RUN mkdir /rit && \
     apk add --no-cache sudo curl bash nodejs && \

--- a/templates/create_formula/languages/node/config.json
+++ b/templates/create_formula/languages/node/config.json
@@ -1,5 +1,5 @@
 {
-  "dockerImageBuilder": "cimg/node:14.0",
+  "dockerImageBuilder": "kobuti/make-runner:1.0.0",
   "inputs": [
     {
       "cache": {

--- a/templates/create_formula/languages/node/config.json
+++ b/templates/create_formula/languages/node/config.json
@@ -1,5 +1,5 @@
 {
-  "dockerImageBuilder": "kobuti/make-runner:1.0.0",
+  "dockerImageBuilder": "kobuti/make-runner:1.1.0",
   "inputs": [
     {
       "cache": {

--- a/templates/create_formula/root/.gitignore
+++ b/templates/create_formula/root/.gitignore
@@ -245,3 +245,7 @@ dist
 # End of https://www.toptal.com/developers/gitignore/api/node
 
 package-lock.json
+
+# Csharp output directories
+**/obj/**
+**/bin/**


### PR DESCRIPTION
**- What I did**
Created a make-runner image for build formula stage. It can be verified [here](https://hub.docker.com/repository/docker/kobuti/make-runner)

Reduced the size of final formula image (nodejs) from 967mb to 43.8mb. This also reduced the first time run of the formula from minutes to seconds.

Added obj/Debug and bin/Debug (from csharp template) to .gitignore. They kept being added when Omnisharp is running trying to background compile any .net code that is on vscode working directory.

**- How I did it**
Created a very very simple image from alpine with make.

Switch base image of NodeJS template from [cimg/node:14](https://hub.docker.com/r/cimg/node) to [alpine:3.12](https://hub.docker.com/_/alpine).
Also change the order of Docker commands to generate less layers reducing even more the size of image.

**- How to verify it**
Run docker build -t image_name . from the nodejs template folder

**- Description for the changelog**
- Reduced the final image size of make runner to less than 6mb
- Reduced the final image size of nodejs template to less than 50mb

**- A picture of a cute animal (not mandatory but encouraged)**
Since it's encouraged, here it is:

![pork](https://static.boredpanda.com/blog/wp-content/uuuploads/cute-baby-animals/cute-baby-animals-10.jpg)
