### PR TITLE
Fix Makefile

### DIFF
--- a/templates/create_formula/languages/ruby/Makefile
+++ b/templates/create_formula/languages/ruby/Makefile
@@ -8,12 +8,15 @@ build: ruby-build docker
 ruby-build:
 	mkdir -p $(BIN_FOLDER)
 	cp -r src/* $(BIN_FOLDER)
+	bundle install --gemfile $(BIN_FOLDER)/Gemfile
+
 	echo '#!/bin/sh' > $(BIN_FOLDER)/$(BINARY_NAME_UNIX)
-	echo 'bundle install --quiet --gemfile "$$(dirname "$$0")"/Gemfile'  >> $(BIN_FOLDER)/$(BINARY_NAME_UNIX)
 	echo 'ruby "$$(dirname "$$0")"/index.rb' >> $(BIN_FOLDER)/$(BINARY_NAME_UNIX)
 
-	echo 'bundle install --gemfile "$$(dirname "$$0")"/Gemfile' >> $(BIN_FOLDER)/$(BINARY_NAME_WINDOWS)
-	echo 'ruby "$$(dirname "$$0")"/index.rb' >> $(BIN_FOLDER)/$(BINARY_NAME_WINDOWS)
+	echo '@ECHO OFF' > $(BIN_FOLDER)/$(BINARY_NAME_WINDOWS)
+	echo 'SET mypath=%~dp0' >> $(BIN_FOLDER)/$(BINARY_NAME_WINDOWS)
+	echo 'ruby %mypath:~0,-1%/index.rb' >> $(BIN_FOLDER)/$(BINARY_NAME_WINDOWS)
+
 	chmod +x $(BIN_FOLDER)/$(BINARY_NAME_UNIX)
 
 docker:


### PR DESCRIPTION
# Pull Request

The installations of the premises were made in the execution of the formula, however it should be done in the build. The Makefile has been adjusted to include this correction.

## What I did

I adjusted the makefile file.

## How I did it

The bundle install command has been removed from the `BINARY_NAME_WINDOWS` and `BINARY_NAME_UNIX` variables to the start of make execution.

## How to verify it

run `rit create formula` and select `ruby` as programming language

## What kind of change does this PR make

- [ ] Major
- [ ] Minor
- [x] Patch

## Description for the changelog

Fixed Makefile