### PR TITLE
Adding dependency for php template

### DIFF
--- a/templates/create_formula/languages/go/Dockerfile
+++ b/templates/create_formula/languages/go/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM cimg/go:1.14
 
 USER root
 

--- a/templates/create_formula/languages/php/Makefile
+++ b/templates/create_formula/languages/php/Makefile
@@ -7,10 +7,11 @@ build: php-build docker
 
 php-build:
 	mkdir -p $(BIN_FOLDER)
+	cp -r src/* $(BIN_FOLDER)
+    composer install -q -d $(BIN_FOLDER)
 	echo '#!/bin/sh' > $(BIN_FOLDER)/$(BINARY_NAME_UNIX)
 	echo 'php -f "$$(dirname "$$0")"//index.php' >>  $(BIN_FOLDER)/$(BINARY_NAME_UNIX)
 	echo 'php -f index.php' > $(BIN_FOLDER)/$(BINARY_NAME_WINDOWS)
-	cp -r src/* $(BIN_FOLDER)
 	chmod +x $(BIN_FOLDER)/$(BINARY_NAME_UNIX)
 
 docker:

--- a/templates/create_formula/languages/php/build.bat
+++ b/templates/create_formula/languages/php/build.bat
@@ -7,6 +7,9 @@ SET SH_FILE=%BIN_FOLDER%\run.sh
 :build
     mkdir %BIN_FOLDER%
     xcopy /E /I src %BIN_FOLDER%
+    cd %BIN_FOLDER%
+    call composer install -q
+    cd ..
     CALL :BAT_WINDOWS
     CALL :SH_LINUX
     CALL :CP_DOCKER

--- a/templates/create_formula/languages/php/src/composer.json
+++ b/templates/create_formula/languages/php/src/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "codedungeon/php-cli-colors": "~1.0"
+    }
+}

--- a/templates/create_formula/languages/php/src/formula/formula.php
+++ b/templates/create_formula/languages/php/src/formula/formula.php
@@ -1,8 +1,10 @@
 <?php
-	function Run($input1, $input2, $input3) {
-		echo "Hello World! \n";
-		echo "You receive $input1 in text. \n";
-		echo "You receive $input2 in list. \n";
-		echo "You receive $input3 in boolean. \n";
-	}
+use Codedungeon\PHPCliColors\Color;
+
+function Run($input1, $input2, $input3) {
+    echo "Hello World! \n";
+    echo Color::GREEN, "You receive $input1 in text. \n";
+    echo Color::RED, "You receive $input2 in list. \n";
+    echo Color::BLUE, "You receive $input3 in boolean. \n";
+}
 ?>

--- a/templates/create_formula/languages/php/src/index.php
+++ b/templates/create_formula/languages/php/src/index.php
@@ -1,7 +1,9 @@
 <?php
-    include 'formula/formula.php';
-    $input1 = getenv('SAMPLE_TEXT');
-    $input2 = getenv('SAMPLE_LIST');
-    $input3 = getenv('SAMPLE_BOOL');
-    Run($input1, $input2, $input3);
+require __DIR__ . '/vendor/autoload.php';
+include 'formula/formula.php';
+
+$input1 = getenv('SAMPLE_TEXT');
+$input2 = getenv('SAMPLE_LIST');
+$input3 = getenv('SAMPLE_BOOL');
+Run($input1, $input2, $input3);
 ?>


### PR DESCRIPTION
<!--
Customized from the template
(https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/ritchie-formulas/blob/master/CONTRIBUTING.md

For additional information on our contributing process, read our contributing
guide https://docs.ritchiecli.io/community

Please provide the following information:
-->

<!-- markdownlint-disable MD018 -->

## Pull Request

## Description

Php formulas were missing their dependency manager on `composer`, this PR includes

- [x] Adding dependency management to php
- [x] Tested dependency management for Mac OS
- [x] Added dependency management for Linux and Windows (untested)
- [x] Tested Docker for Mac OS

Note: requires `composer` installed

## How to verify it

Create a php formula

## What kind of change does this PR make

- [ ] Major
- [x] Minor
- [ ] Patch

<!--
See: https://semver.org/
-->

## Description for the changelog

Added dependency manager for php formulas

## Screenshot

<img width="310" alt="Screen Shot 2020-09-02 at 20 29 17" src="https://user-images.githubusercontent.com/3487122/92047479-9b357480-ed5b-11ea-95b7-f4dea4199cac.png">

