### PR TITLE
[FIX] - Remove venv from python template

### DIFF
--- a/templates/create_formula/languages/python3/Dockerfile
+++ b/templates/create_formula/languages/python3/Dockerfile
@@ -10,6 +10,8 @@ RUN sed -i 's/\r//g' /rit/set_umask.sh
 RUN sed -i 's/\r//g' /rit/run.sh
 RUN chmod +x /rit/set_umask.sh
 
+ENV DOCKER_EXECUTION=true
+
 WORKDIR /app
 ENTRYPOINT ["/rit/set_umask.sh"]
 CMD ["/rit/run.sh"]

--- a/templates/create_formula/languages/python3/Makefile
+++ b/templates/create_formula/languages/python3/Makefile
@@ -9,30 +9,18 @@ build: python-build sh_unix bat_windows docker
 python-build:
 	mkdir -p $(BIN_FOLDER)
 	cp -r src/* $(BIN_FOLDER)
-
-	# Config VENV
-	echo '#!/bin/bash' > $(BIN_FOLDER)/$(BIN_CONFIG_VENV)
-	echo 'python3 -m venv --clear "$$(dirname "$$0")"/venv' >> $(BIN_FOLDER)/$(BIN_CONFIG_VENV)
-	echo 'source ./"$$(dirname "$$0")"/venv/bin/activate' >> $(BIN_FOLDER)/$(BIN_CONFIG_VENV)
-	echo 'pip3 install -r "$$(dirname "$$0")"/requirements.txt' >> $(BIN_FOLDER)/$(BIN_CONFIG_VENV)
-	chmod +x $(BIN_FOLDER)/$(BIN_CONFIG_VENV)
-	./$(BIN_FOLDER)/$(BIN_CONFIG_VENV)
-
-	# Fix lib64
-	rm ./$(BIN_FOLDER)/venv/lib64
-	cp -r ./$(BIN_FOLDER)/venv/lib/ ./$(BIN_FOLDER)/venv/lib64
+	pip3 install -r $(BIN_FOLDER)/requirements.txt
 
 sh_unix:
 	echo '#!/bin/bash' > $(BIN_FOLDER)/$(BINARY_NAME)
-	echo 'source "$$(dirname "$$0")"/venv/bin/activate' >> $(BIN_FOLDER)/$(BINARY_NAME)
+	echo 'if [[ $$DOCKER_EXECUTION ]] ; then' >> $(BIN_FOLDER)/$(BINARY_NAME)
+	echo '	pip3 install -r "$$(dirname "$$0")"/requirements.txt >> /dev/null' >> $(BIN_FOLDER)/$(BINARY_NAME)
+	echo 'fi' >> $(BIN_FOLDER)/$(BINARY_NAME)
 	echo 'python3 "$$(dirname "$$0")"/main.py' >> $(BIN_FOLDER)/$(BINARY_NAME)
-	echo 'deactivate' >> $(BIN_FOLDER)/$(BINARY_NAME)
 	chmod +x $(BIN_FOLDER)/$(BINARY_NAME)
 
 bat_windows:
-	echo '"$$(dirname "$$0")"/venv/bin/activate.bat' >> $(BIN_FOLDER)/$(BINARY_NAME_WINDOWS)
 	echo 'python main.py' >> $(BIN_FOLDER)/$(BINARY_NAME_WINDOWS)
-	echo 'deactivate.bat' >> $(BIN_FOLDER)/$(BINARY_NAME_WINDOWS)
 
 docker:
 	cp Dockerfile set_umask.sh $(BIN_FOLDER)


### PR DESCRIPTION
# Pull Request

## Description

The installation of dependencies with VENV is causing conflicts in the build with docker, so as it was not possible to find a definitive solution at the moment, we will remove VENV and leave the installation of default dependencies.

Below the demonstration of execution with or without docker, regardless of order of execution.

![pyhton-docker](https://user-images.githubusercontent.com/58859234/94160675-3dc4ad00-fe5b-11ea-95c1-b881ba375407.gif)

## What kind of change does this PR make

- [ ] Major
- [ ] Minor
- [x] Patch

## Description for the changelog
- Remove VENV of python template
