### PR TITLE
Fix pre-commit and add support do run on windows

### DIFF
--- a/pre-commit.bat
+++ b/pre-commit.bat
@@ -1,0 +1,3 @@
+@echo off
+docker build . -t precommit -f preCommit.Dockerfile
+docker run -it -v %cd%:/app -v %userprofile%\.precommit\.cache:/root/.cache precommit

--- a/preCommit.Dockerfile
+++ b/preCommit.Dockerfile
@@ -1,4 +1,4 @@
-FROM circleci/python:latest
+FROM circleci/python:3.8.5
 
 USER root
 


### PR DESCRIPTION
Signed-off-by: Fabiano Chiareto Fernandes <fabiano.fernandes@zup.com.br>

# Pull Request

## Description

Add script bat to run pre-commit with docker on windows. Fix version docker image.

## What kind of change does this PR make

- [ ] Major
- [ ] Minor
- [x] Patch

## Description for the changelog
- Fix pre-commit and add support do run on windows