### PR TITLE
Update Rust template to match hello-world formula

### DIFF
--- a/templates/create_formula/languages/rust/README.md
+++ b/templates/create_formula/languages/rust/README.md
@@ -1,11 +1,11 @@
 # Ritchie Formula
 
-## command
+## Command
 
 ```bash
 #rit-replace{formulaCmd}
 ```
 
-## description
+## Description
 
-description of formula
+Formula description 

--- a/templates/create_formula/languages/rust/config.json
+++ b/templates/create_formula/languages/rust/config.json
@@ -5,22 +5,10 @@
       "cache": {
         "active": true,
         "newLabel": "Type new value. ",
-        "qty": 6
+        "qty": 3
       },
-      "label": "Type : ",
-      "name": "sample_text",
-      "type": "text"
-    },
-    {
-      "default": "in1",
-      "items": [
-        "in_list1",
-        "in_list2",
-        "in_list3",
-        "in_listN"
-      ],
-      "label": "Pick your : ",
-      "name": "sample_list",
+      "label": "Type your name: ",
+      "name": "input_text",
       "type": "text"
     },
     {
@@ -29,9 +17,26 @@
         "false",
         "true"
       ],
-      "label": "Pick: ",
-      "name": "sample_bool",
+      "label": "Have you ever used Ritchie? ",
+      "name": "input_boolean",
       "type": "bool"
+    },
+    {
+      "default": "everything",
+      "items": [
+        "daily tasks",
+        "workflows",
+        "toils",
+        "everything"
+      ],
+      "label": "What do you want to automate? ",
+      "name": "input_list",
+      "type": "text"
+    },
+    {
+      "label": "Tell us a secret: ",
+      "name": "input_password",
+      "type": "password"
     }
   ]
 }

--- a/templates/create_formula/languages/rust/src/src/formula/mod.rs
+++ b/templates/create_formula/languages/rust/src/src/formula/mod.rs
@@ -1,8 +1,21 @@
 use colored::*;
 
-pub fn run(sample_text: String, sample_list: String, sample_bool: String) {
+pub fn run(input_text: String, input_bool: bool, input_list: String, input_password: String) {
     println!("Hello World!");
-    println!("{}", format!("You receive {} in text.", sample_text).blue());
-    println!("{}", format!("You receive {} in list.", sample_list).green());
-    println!("{}", format!("You receive {} in boolean.", sample_bool).red());
+    println!("{}", format!("My name is {}.", input_text).green());
+
+    if input_bool {
+        println!("{}", "I’ve already created formulas using Ritchie.".red())
+    } else {
+        println!(
+            "{}",
+            "I’m excited in creating new formulas using Ritchie.".red()
+        )
+    }
+
+    println!(
+        "{}",
+        format!("Today, I want to automate {}.", input_list).yellow()
+    );
+    println!("{}", format!("My secret is {}.", input_password).cyan());
 }

--- a/templates/create_formula/languages/rust/src/src/main.rs
+++ b/templates/create_formula/languages/rust/src/src/main.rs
@@ -3,24 +3,26 @@ mod formula;
 use std::env;
 
 fn main() {
-	let sample_text;
-	let sample_list;
-  let sample_bool;
+    let input_text = string_from_env("INPUT_TEXT");
 
-	match env::var("SAMPLE_TEXT") {
-		Ok(val) => sample_text = val,
-		Err(_e) => sample_text = "none".to_string(),
-  }
+    let input_bool = bool_from_env("INPUT_BOOLEAN");
 
-	match env::var("SAMPLE_LIST") {
-		Ok(val) => sample_list = val,
-		Err(_e) => sample_list = "none".to_string(),
-  }
+    let input_list = string_from_env("INPUT_LIST");
+    let input_password = string_from_env("INPUT_PASSWORD");
 
-	match env::var("SAMPLE_BOOL") {
-		Ok(val) => sample_bool = val,
-		Err(_e) => sample_bool = "none".to_string(),
-  }
+    formula::run(input_text, input_bool, input_list, input_password);
+}
 
-	formula::run(sample_text, sample_list, sample_bool);
+fn string_from_env(key: &str) -> String {
+    match env::var(key) {
+        Ok(val) => val,
+        Err(_) => "none".to_string(),
+    }
+}
+
+fn bool_from_env(key: &str) -> bool {
+    match env::var(key) {
+        Ok(val) => val.parse().unwrap_or(false),
+        Err(_) => false,
+    }
 }


### PR DESCRIPTION
Closes #187 

Signed-off-by: Anthony Jones <anthony@beforeman.co>

# Pull Request

## What I did

Updated the Rust template to show the four ritchie input methods and match the language and colors to the hello-world formula.

<img width="361" alt="Screen Shot 2020-10-01 at 2 35 07 PM" src="https://user-images.githubusercontent.com/5115854/94849417-60bf0600-03f3-11eb-95ee-8fccc548f691.png">

## How I did it

Used the [hello-world formula](https://github.com/ZupIT/ritchie-formulas-demo/tree/master/demo/hello-world) as a guideline.

## How to verify it

Direct comparison to the hello-world command: `rit demo hello-world`.

From the fork, with the rust toolchain:
```
cd templates/create_formula/languages/rust/
export INPUT_TEXT=senoja
export INPUT_LIST=toils
export INPUT_BOOLEAN=false
export INPUT_PASSWORD=none

cargo run 
```


You might laugh but this is what I came up with for a final validation using the cli:
```
rit delete repo # remove commons and re-add commons from my fork
echo '{"provider":"Github", "name":"commons", "version":"exp", "url":"https://github.com/senoja/ritchie-formulas-demo", "token": null, "priority":0}' | rit add repo --stdin
rit create formula # selecting the rust option and "rit senoja rust update"
rit senoja rust update
```

## What kind of change does this PR make

- [ ] Major
- [x] Minor
- [ ] Patch

## Description for the changelog

- Updated Rust template to match hello-world demo
