### PR TITLE
Update Shell template to match hello-world formula

### DIFF
--- a/templates/create_formula/languages/shell/config.json
+++ b/templates/create_formula/languages/shell/config.json
@@ -5,23 +5,12 @@
       "cache": {
         "active": true,
         "newLabel": "Type new value. ",
-        "qty": 6
+        "qty": 3
       },
-      "label": "Type : ",
-      "name": "sample_text",
-      "type": "text"
-    },
-    {
-      "default": "in1",
-      "items": [
-        "in_list1",
-        "in_list2",
-        "in_list3",
-        "in_listN"
-      ],
-      "label": "Pick your : ",
-      "name": "sample_list",
-      "type": "text"
+      "label": "Type your name: ",
+      "name": "input_text",
+      "type": "text",
+      "tutorial": "Your prefer name"
     },
     {
       "default": "false",
@@ -29,9 +18,29 @@
         "false",
         "true"
       ],
-      "label": "Pick: ",
-      "name": "sample_bool",
-      "type": "bool"
+      "label": "Have you ever used Ritchie? ",
+      "name": "input_boolean",
+      "type": "bool",
+      "tutorial": "Choose one option"
+    },
+    {
+      "default": "everything",
+      "items": [
+        "daily tasks",
+        "workflows",
+        "toils",
+        "everything"
+      ],
+      "label": "What do you want to automate? ",
+      "name": "input_list",
+      "type": "text",
+      "tutorial": "Select what you want to automate with Ritchie"
+    },
+    {
+      "label": "Tell us a secret: ",
+      "name": "input_password",
+      "type": "password",
+      "tutorial": "Type a secret"
     }
   ]
 }

--- a/templates/create_formula/languages/shell/src/formula/formula.sh
+++ b/templates/create_formula/languages/shell/src/formula/formula.sh
@@ -1,7 +1,36 @@
 #!/bin/sh
+
 runFormula() {
   echo "Hello World! "
-  echo "You receive $SAMPLE_TEXT in text. "
-  echo "You receive $SAMPLE_LIST in list. "
-  echo "You receive $SAMPLE_BOOL in boolean. "
+  echoColor "green" "My name is $1."
+
+  if [ "$2" = "true" ]; then
+    echoColor "blue" "I've already created formulas using Ritchie."
+  else
+    echoColor "red" "I'm excited in creating new formulas using Ritchie."
+  fi
+
+  echoColor "yellow" "Today, I want to automate $3."
+  echoColor "cyan"  "My secret is $4."
 }
+
+echoColor() {
+  case $1 in
+    red)
+      echo "$(printf '\033[31m')$2$(printf '\033[0m')"
+      ;;
+    green)
+      echo "$(printf '\033[32m')$2$(printf '\033[0m')"
+      ;;
+    yellow)
+      echo "$(printf '\033[33m')$2$(printf '\033[0m')"
+      ;;
+    blue)
+      echo "$(printf '\033[34m')$2$(printf '\033[0m')"
+      ;;
+    cyan)
+      echo "$(printf '\033[36m')$2$(printf '\033[0m')"
+      ;;
+    esac
+}
+

--- a/templates/create_formula/languages/shell/src/main.sh
+++ b/templates/create_formula/languages/shell/src/main.sh
@@ -4,4 +4,4 @@
 . "$(dirname "$0")"/formula/formula.sh --source-only
 #In sh for receive inputs of CLI use: $SAMPLE_TEXT, $SAMPLE_LIST and $SAMPLE_BOOL for this example
 
-runFormula "$SAMPLE_TEXT" "$SAMPLE_LIST" "$SAMPLE_BOOL"
+runFormula "$INPUT_TEXT" "$INPUT_BOOLEAN" "$INPUT_LIST" "$INPUT_PASSWORD"


### PR DESCRIPTION
Closes #259 

Signed-off-by: Anthony Jones <anthony@beforeman.co>

# Pull Request

## What I did

Updated the Shell template to show the four ritchie input methods and match the language and colors to the hello-world formula.

<img width="644" alt="Screen Shot 2020-10-04 at 12 18 10 PM" src="https://user-images.githubusercontent.com/5115854/95024940-20aa8e00-0654-11eb-9f41-7c69dd65ed7f.png">

## How I did it

Used the [hello-world formula](https://github.com/ZupIT/ritchie-formulas-demo/tree/master/demo/hello-world) as a guideline.

## How to verify it

Direct comparison to the hello-world command: `rit demo hello-world`.

From the fork, from a shell:
```
export INPUT_TEXT=senoja
export INPUT_LIST=toils
export INPUT_BOOLEAN=false
export INPUT_PASSWORD=none
templates/create_formula/languages/shell/src/main.sh
```

## What kind of change does this PR make

- [ ] Major
- [x] Minor
- [ ] Patch

## Description for the changelog

- Updated Shell template to match hello-world demo
