### PR TITLE
Update RIT AWS APPLY TERRAFORM formula README (#196)

### DIFF
--- a/aws/apply/terraform/README.md
+++ b/aws/apply/terraform/README.md
@@ -2,7 +2,6 @@
 
 ## Premisses
 
-- [Golang installed](https://golang.org/doc/install)
 - [Terraform installed](https://www.terraform.io/downloads.html)
 - Set Github credentials
 - Set AWS credentials
@@ -11,29 +10,39 @@ You can set credentials by running *rit set credential* and providing USERNAME, 
 
 ## Command
 
-- Prompt
+- Prompt 
 
 ```bash
 rit aws apply terraform
 ```
 
-- Docker
+*It is necessary to have [Golang installed](https://golang.org/doc/install) for this command to work*
+
+- Docker 
+
 
 ```bash
 rit aws apply terraform --docker
 ```
 
-- Stdin
+*It is necessary to have [Docker installed](https://docs.docker.com/get-docker) for this command to work*
+
+
+- Stdin 
 
 ```bash
 echo '{"repository":"https://github.com/eduardorcury/ritchie-demo", "terraform_path":"/terraform", "environment":"dev"}' | rit aws apply terraform --stdin
 ```
 
-- Stdin + Docker
+*It is necessary to have [Golang installed](https://golang.org/doc/install) for this command to work*
+
+- Stdin + Docker 
 
 ```bash
 echo '{"repository":"https://github.com/eduardorcury/ritchie-demo", "terraform_path":"/terraform", "environment":"dev"}' | rit aws apply terraform --stdin --docker
 ```
+
+*It is necessary to have [Docker installed](https://docs.docker.com/get-docker) for this command to work*
 
 ## Description
 

--- a/aws/apply/terraform/README.md
+++ b/aws/apply/terraform/README.md
@@ -1,7 +1,68 @@
 # Terraform aws apply
 
-## command
+## Premisses
+
+- [Golang installed](https://golang.org/doc/install)
+- [Terraform installed](https://www.terraform.io/downloads.html)
+- Set Github credentials
+- Set AWS credentials
+
+You can set credentials by running *rit set credential* and providing USERNAME, TOKEN and EMAIL for Github and ACCESS KEY ID and SECRET ACCESS KEY for AWS.
+
+## Command
+
+- Prompt
 
 ```bash
 rit aws apply terraform
 ```
+
+- Docker
+
+```bash
+rit aws apply terraform --docker
+```
+
+- Stdin
+
+```bash
+echo '{"repository":"https://github.com/eduardorcury/ritchie-demo", "terraform_path":"/terraform", "environment":"dev"}' | rit aws apply terraform --stdin
+```
+
+- Stdin + Docker
+
+```bash
+echo '{"repository":"https://github.com/eduardorcury/ritchie-demo", "terraform_path":"/terraform", "environment":"dev"}' | rit aws apply terraform --stdin --docker
+```
+
+## Description
+
+This command allows the user to execute terraform init, terraform plan and terraform apply command on a given repository. The command also loads the variables located on the files './variables/common.tfvars' and 'variables/**env**.tfvars', where **env** is the environment name provided.
+
+Note that this command will clone the provided repository in the present working directory.
+
+The user has to provide 3 inputs:
+
+- the repository URL
+
+- the path to the terraform files
+
+- the environment name
+
+The equivalent terraform apply command is:
+
+```bash
+terraform apply -var-file=./variables/common.tfvars -var-file=variables/{ENV}.tfvars -auto-approve
+```
+
+## Demonstration
+
+- Command execution
+
+![Demo gif](https://github.com/eduardorcury/ritchie-demo/blob/main/media/rit-demo.gif)
+
+- The created resource
+
+In this demo, an AWS IAM user was created using terraform and ritchie.
+
+![Img](https://github.com/eduardorcury/ritchie-demo/blob/main/media/resource-img.png)

--- a/aws/apply/terraform/config.json
+++ b/aws/apply/terraform/config.json
@@ -3,7 +3,7 @@
   "inputs": [
     {
       "default": "https://github.com/zupit/iti-stack-core",
-      "label": "Select your repository URL: ",
+      "label": "Type your repository URL: ",
       "name": "repository",
       "type": "text",
       "tutorial": "Inform your repository URL e.g.: https://github.com/zupit/iti-stack-core"

--- a/aws/apply/terraform/config.json
+++ b/aws/apply/terraform/config.json
@@ -3,14 +3,10 @@
   "inputs": [
     {
       "default": "https://github.com/zupit/iti-stack-core",
-      "items": [
-        "https://github.com/zupit/iti-stack-core",
-        "https://github.com/zupit/iti-stack-tools"
-      ],
       "label": "Select your repository URL: ",
       "name": "repository",
       "type": "text",
-      "tutorial": "Choose one option"
+      "tutorial": "Inform your repository URL e.g.: https://github.com/zupit/iti-stack-core"
     },
     {
       "default": "src",


### PR DESCRIPTION
# Pull Request

## What I did

Update on the README file of the *aws apply terraform* command. 
I also changed the config.json file to allow the user to type the repository URL, instead of selecting it (see comments on https://github.com/ZupIT/ritchie-formulas/issues/196)

## How I did it

I searched the documentation to rebuild the formula and test it.

## How to verify it

Run *rit aws apply terraform* and read de README.md.

## What kind of change does this PR make

- [ ] Major
- [x] Minor
- [ ] Patch

## Description for the changelog

Updating aws apply terraform README and changing the repository URL input from "select" to "type".
