### PR TITLE
Temporarily disable pre-commit hooks for python

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,8 +15,8 @@ repos:
       - id: trailing-whitespace
       - id: detect-private-key
 
-      - id: flake8
-      - id: check-ast
+      # - id: flake8
+      # - id: check-ast
       - id: end-of-file-fixer
 
   - repo: git://github.com/igorshubovych/markdownlint-cli


### PR DESCRIPTION
Signed-off-by: maurineimirandazup <maurinei.miranda@zup.com.br>

<!--
Customized from the template
(https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/ritchie-formulas/blob/master/CONTRIBUTING.md

For additional information on our contributing process, read our contributing
guide https://docs.ritchiecli.io/community

Please provide the following information:
-->

<!-- markdownlint-disable MD018 -->

# Pull Request

## What I did
Temporarily disable hooks for python.
Until you find a solution for both versions of python.
## How I did it
In the pre-commit configuration I commented on the hooks lines:
flake8, check-ast
## How to verify it
When opening a new PR, the pipeline will not break.
## What kind of change does this PR make

- [ ] Major
- [x] Minor
- [ ] Patch

<!--
See: https://semver.org/
-->

## Description for the changelog

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
