### PR TITLE
Including MySQL template for "rit docker generate compose" formula. 

### DIFF
--- a/docker/generate/compose/src/main.go
+++ b/docker/generate/compose/src/main.go
@@ -9,13 +9,18 @@ func main() {
 	var selectItems []string
 	selectItem := ""
 	var extParams = make(map[string]string)
-	items := []string{"awsclivl", "consul", "dynamoDB", "jaeger", "kafka", "mongo", "postgres", "redis", "stubby4j", "rabbitmq", "finish!"}
+	items := []string{"awsclivl", "consul", "dynamoDB", "jaeger", "kafka", "mongo", "postgres", "mysql", "redis", "stubby4j", "rabbitmq", "finish!"}
 	for selectItem != "finish!" {
 		selectItem, _ = prompt.List("Select docker image: ", items)
 		if selectItem == "postgres" {
 			extParams["postgresDB"], _ = prompt.String("Type DB name: ", true)
 			extParams["postgresUser"], _ = prompt.String("Type DB user: ", true)
 			extParams["postgresPassword"], _ = prompt.StringPwd("Type DB password: ")
+		}
+		if selectItem == "mysql" {
+			extParams["mysqlDB"], _ = prompt.String("Type DB name: ", true)
+			extParams["mysqlUser"], _ = prompt.String("Type DB user: ", true)
+			extParams["mysqlPassword"], _ = prompt.StringPwd("Type DB password: ")
 		}
 		if selectItem == "mongo" {
 			extParams["mongoWebClientUser"], _ = prompt.String("Type Mongo WebClient user: ", true)

--- a/docker/generate/compose/src/pkg/compose/compose.go
+++ b/docker/generate/compose/src/pkg/compose/compose.go
@@ -51,6 +51,15 @@ services:`
       - POSTGRES_PASSWORD={{POSTGRES_PASSWORD}}
       - MAX_CONNECTIONS=300`
 
+	mysqlYml = `  mysql:
+    image: mysql:8.0
+    ports:
+      - "3307:3306"
+    environment:
+      - MYSQL_DATABASE={{MYSQL_DB}}
+      - MYSQL_USER={{MYSQL_USER}}
+      - MYSQL_ROOT_PASSWORD={{MYSQL_PASSWORD}}`
+
 	mongoYml = `  mongo:
     image: mongo
     restart: always
@@ -163,6 +172,12 @@ func GenerateYml(items []string, extParams map[string]string) {
 				postgresYmlString = strings.Replace(postgresYmlString, "{{POSTGRES_USER}}", extParams["postgresUser"], -1)
 				postgresYmlString = strings.Replace(postgresYmlString, "{{POSTGRES_PASSWORD}}", extParams["postgresPassword"], -1)
 				ymlString = fmt.Sprintf("%s%s\n\n", ymlString, postgresYmlString)
+			case "mysql":
+				mysqlYmlString := mysqlYml
+				mysqlYmlString = strings.Replace(mysqlYmlString, "{{MYSQL_DB}}", extParams["mysqlDB"], -1)
+				mysqlYmlString = strings.Replace(mysqlYmlString, "{{MYSQL_USER}}", extParams["mysqlUser"], -1)
+				mysqlYmlString = strings.Replace(mysqlYmlString, "{{MYSQL_PASSWORD}}", extParams["mysqlPassword"], -1)
+				ymlString = fmt.Sprintf("%s%s\n\n", ymlString, mysqlYmlString)
 			case "mongo":
 				mongoYmlString := mongoYml
 				mongoYmlString = strings.Replace(mongoYmlString, "{{MONGO_WEBCLIENT_USER}}", extParams["mongoWebClientUser"], -1)


### PR DESCRIPTION
Signed-off-by: idnilson <juniormoraisidejr@gmail.com>

<!--
Customized from the template
(https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/ritchie-formulas/blob/master/CONTRIBUTING.md

For additional information on our contributing process, read our contributing
guide https://docs.ritchiecli.io/community

Please provide the following information:
-->

<!-- markdownlint-disable MD018 -->

# Pull Request

## What I did
This template was not present and I would like to make this contribution to the project in the generation of docker-compose.yml
## How I did it
Changing the files compose.go and main.go it was possible to analyze what would be needed
## How to verify it
Running the formula "rit docker generate compose" is currently not present in MySQL. With my change it will be possible to use it:

```
---
version: '2'
services:
  mysql:
    image: mysql:8.0
    ports:
      - "3307:3306"
    environment:
      - MYSQL_DATABASE=test_db
      - MYSQL_USER=myusername
      - MYSQL_ROOT_PASSWORD=mypassword
```


## What kind of change does this PR make

- [ ] Major
- [ x ] Minor
- [ ] Patch

<!--
See: https://semver.org/
-->

## Description for the changelog
Including MySQL template for "rit docker generate compose" formula. 

